### PR TITLE
Add agent flags to sample cr

### DIFF
--- a/config/samples/flows_v1beta1_flowcollector.yaml
+++ b/config/samples/flows_v1beta1_flowcollector.yaml
@@ -22,6 +22,9 @@ spec:
         limits:
           memory: 800Mi
       kafkaBatchSize: 10485760
+      privileged: false
+      enableTCPDrop: false
+      enableDNSTracking: false
   processor:
     port: 2055
     imagePullPolicy: IfNotPresent


### PR DESCRIPTION
@msherif1234 this is a suggestion to add these flags in the sample CR - that's useful when deploying & tuning the CR without having to retrieve the names of these fields